### PR TITLE
fixed MaterialElementsViewInflater error at runtime

### DIFF
--- a/material-elements/java/com/zeoflow/material/elements/dialog/res/values/themes_base.xml
+++ b/material-elements/java/com/zeoflow/material/elements/dialog/res/values/themes_base.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (C) 2020 ZeoFlow
+  ~ Copyright (C) 2021 ZeoFlow
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 
   <style name="Base.V14.Theme.MaterialElements.Dialog" parent="Base.V14.Theme.MaterialElements.Dialog.Bridge">
     <item name="viewInflaterClass">
-      com.zeoflow.theme.MaterialElementsViewInflater
+      com.zeoflow.material.elements.theme.MaterialElementsViewInflater
     </item>
 
     <item name="colorPrimary">@color/design_dark_default_color_primary</item>
@@ -77,7 +77,7 @@
 
   <style name="Base.V14.Theme.MaterialElements.Light.Dialog" parent="Base.V14.Theme.MaterialElements.Light.Dialog.Bridge">
     <item name="viewInflaterClass">
-      com.zeoflow.theme.MaterialElementsViewInflater
+      com.zeoflow.material.elements.theme.MaterialElementsViewInflater
     </item>
 
     <!-- Colors -->

--- a/material-elements/java/com/zeoflow/material/elements/theme/res/values/themes_base.xml
+++ b/material-elements/java/com/zeoflow/material/elements/theme/res/values/themes_base.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (C) 2020 ZeoFlow
+  ~ Copyright (C) 2021 ZeoFlow
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 
   <style name="Base.V14.Theme.MaterialElements" parent="Base.V14.Theme.MaterialElements.Bridge">
     <item name="viewInflaterClass">
-      com.zeoflow.theme.MaterialElementsViewInflater
+      com.zeoflow.material.elements.theme.MaterialElementsViewInflater
     </item>
 
     <!-- Colors -->
@@ -93,7 +93,7 @@
 
   <style name="Base.V14.Theme.MaterialElements.Light" parent="Base.V14.Theme.MaterialElements.Light.Bridge">
     <item name="viewInflaterClass">
-      com.zeoflow.theme.MaterialElementsViewInflater
+      com.zeoflow.material.elements.theme.MaterialElementsViewInflater
     </item>
 
     <!-- Colors -->


### PR DESCRIPTION
old path: `com.zeoflow.theme.MaterialElementsViewInflater`

new path: `com.zeoflow.material.elements.theme.MaterialElementsViewInflater`

**TO-DO**
Table of Contents
> - [x] It solves an issue
  > - [x] Link to GitHub issues it solves.
      `closes #53`

[Contributing](https://github.com/zeoflow/material-elements/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
