### PR TITLE
All fields from the `ShimmerParams` are now public

### DIFF
--- a/material-elements/java/com/zeoflow/material/elements/shimmer/ShimmerParams.java
+++ b/material-elements/java/com/zeoflow/material/elements/shimmer/ShimmerParams.java
@@ -38,9 +38,9 @@ public class ShimmerParams
     public Shimmer shimmer;
     public boolean defaultChildVisible;
     @ColorInt
-    int baseColor;
+    public int baseColor;
     @ColorInt
-    int highlightColor;
+    public int highlightColor;
 
     public ShimmerParams()
     {


### PR DESCRIPTION
## Table of Contents
### Link to GitHub issues it solves
closes #75
### Description
All fields from the `ShimmerParams` are now public

###### [Contributing](https://github.com/zeoflow/material-elements/blob/master/docs/contributing.md) has more information and tips for a great pull request.